### PR TITLE
Improve homepage SEO and accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# Codex
-Initial commit
+# S&F Agritech Website
+
+This repository contains a static marketing site for S&F Agritech highlighting biostimulant field work services, AI automation workflows, and a heritage apparel line inspired by USDA pest imagery.
+
+## Structure
+
+- `index.html` &mdash; Landing page with overview of offerings and contact CTA.
+- `biostimulant-field-work.html` &mdash; Detailed breakdown of biostimulant trial services.
+- `ai-automation.html` &mdash; Overview of AI automation workflow packages and featured automations.
+- `apparel.html` &mdash; Heritage apparel catalog featuring USDA archive artwork.
+- `assets/css/styles.css` &mdash; Shared styling for the entire site.
+
+## Development
+
+Open any of the HTML files in a browser or serve locally with a static server, for example:
+
+```bash
+python -m http.server 8000
+```
+
+Then visit `http://localhost:8000` to browse the site.

--- a/ai-automation.html
+++ b/ai-automation.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Automation Workflows | S&F Agritech</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <div class="site-wrapper">
+      <header class="subpage-header">
+        <nav>
+          <div class="logo">S&amp;F Agritech</div>
+          <div class="utility-nav">
+            <a href="index.html">Home</a>
+            <a href="biostimulant-field-work.html">Biostimulant Field Work</a>
+            <a href="ai-automation.html">AI Automation Workflows</a>
+            <a href="apparel.html">Heritage Apparel</a>
+            <a href="mailto:hello@sfagritech.com">Contact</a>
+          </div>
+        </nav>
+      </header>
+
+      <section class="page-hero">
+        <nav class="breadcrumb"><a href="index.html">Home</a> &raquo; AI Automation Workflows</nav>
+        <h1>AI Automation for Agronomic Teams</h1>
+        <p>
+          Transform field intelligence into repeatable workflows. We bridge your scouting crews, lab data, and CRM systems using secure automation stacks.
+        </p>
+      </section>
+
+      <main>
+        <section class="split">
+          <div>
+            <h2 class="section-title">From data friction to guided action</h2>
+            <p>
+              Our automation architects blend large language models, computer vision, and low-code tooling to deliver workflows that your agronomy and sales teams can actually adopt. We prioritize compliance, data governance, and ease of use from day one.
+            </p>
+            <ul class="list">
+              <li>Audit of existing scouting logs, lab feeds, and CRM touchpoints</li>
+              <li>Data normalization referencing USDA pest and nutrient naming standards</li>
+              <li>Secure infrastructure staged for deployment on Elestio or your preferred cloud</li>
+              <li>Change management playbooks and training loops for your staff</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Workflow launch packages</h3>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Package</th>
+                  <th>Highlights</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><span class="badge green">Scout Sync</span></td>
+                  <td>AI-generated scouting summaries with USDA pest callouts pushed to your CRM within two hours of field time.</td>
+                </tr>
+                <tr>
+                  <td><span class="badge gold">Nutrient Navigator</span></td>
+                  <td>Automated interpretation of tissue/soil tests aligned to crop growth stages with irrigation and fertigation task triggers.</td>
+                </tr>
+                <tr>
+                  <td><span class="badge green">Retail Bridge</span></td>
+                  <td>Proposal builder that combines trial data, price sheets, and heritage visuals for quick distributor follow-up.</td>
+                </tr>
+                <tr>
+                  <td><span class="badge gold">Irrigation Pulse</span></td>
+                  <td>Canopy stress alerts fused with pump logs to recommend variable-rate sets and alert irrigators by SMS.</td>
+                </tr>
+                <tr>
+                  <td><span class="badge green">Residue Ready</span></td>
+                  <td>MRL and PHI monitoring workflow that syncs spray records with USDA and export market tolerances before harvest.</td>
+                </tr>
+              </tbody>
+            </table>
+            <a class="btn btn-primary" href="mailto:hello@sfagritech.com">Request a sandbox</a>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Featured automations</h2>
+          <div class="grid grid-3">
+            <article class="card">
+              <h3>Scouting voice notes to insights</h3>
+              <p>
+                Field reps record observations. Our workflow transcribes, tags pests using USDA entomology references, and pushes corrective actions into your CRM tasks and Teams/Slack channels.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Trial data storytelling</h3>
+              <p>
+                Replicated trial spreadsheets are converted into storyboards, charts, and pricing one-pagers tuned for distributor sales rides and grower meetings.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Grower nurture sequences</h3>
+              <p>
+                Triggered campaigns send hyper-relevant tips, apparel drops, and field day invites based on crop, phenology, and geography.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Compliance packet builder</h3>
+              <p>
+                Automatically assembles residue, worker safety, and audit documentation with links back to USDA PMRA/APHIS updates for your QA lead.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Canopy stress radar</h3>
+              <p>
+                Fuses drone NDVI, weather data, and pump telemetry to surface urgent sets, trigger alerts, and suggest fertigation recipes.</p>
+            </article>
+            <article class="card">
+              <h3>Retail partner intelligence</h3>
+              <p>
+                Monitors distributor portals and POS data to flag emerging demand, share fresh merchandising assets, and queue inventory replenishment tasks.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="highlight">
+          <h3>Technology stack</h3>
+          <p>
+            We integrate best-in-class platforms while preparing for long-term hosting on Elestio-managed infrastructure for resilience and predictable costs.
+          </p>
+          <div class="badge-list">
+            <span class="badge">Open-source LLM orchestration</span>
+            <span class="badge">GIS &amp; remote sensing overlays</span>
+            <span class="badge">CRM &amp; ERP connectors</span>
+            <span class="badge">USDA taxonomy enrichment</span>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Blueprint library</h2>
+          <p>
+            Every deployment is anchored in a clearly defined trigger, dataset, and regulatory reference. Here are sample workflows we keep staged for rapid customization.
+          </p>
+          <div class="table-wrapper">
+            <table class="table workflow-matrix">
+              <thead>
+                <tr>
+                  <th>Workflow</th>
+                  <th>Trigger</th>
+                  <th>Outputs</th>
+                  <th>USDA touchpoint</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Beneficial release planner</td>
+                  <td>Sticky card counts exceed IPM thresholds</td>
+                  <td>Predator release rates + crew SMS checklist</td>
+                  <td>USDA IPM Fact Sheet 703</td>
+                </tr>
+                <tr>
+                  <td>Heat stress escalation</td>
+                  <td>Forecasted WBGT above 86&deg;F</td>
+                  <td>Shift rotation alerts + bilingual hydration signage</td>
+                  <td>USDA Agricultural Safety Bulletin 915</td>
+                </tr>
+                <tr>
+                  <td>Biofertility inventory guardrail</td>
+                  <td>Inventory dips below reorder point</td>
+                  <td>Purchase order draft + variance dashboard</td>
+                  <td>USDA National Organic Program input log guidance</td>
+                </tr>
+                <tr>
+                  <td>Export residue dossier</td>
+                  <td>Harvest scheduled for export block</td>
+                  <td>PDF dossier with MRL tables + spray log excerpts</td>
+                  <td>USDA FAS MRL Database sync</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="cta">
+          <h2>Imagine your next automation win</h2>
+          <p>
+            Share your field workflows or sales bottlenecks. We&rsquo;ll co-design an automation roadmap anchored in real crop data.
+          </p>
+          <a class="btn btn-primary" href="mailto:hello@sfagritech.com">Schedule a workshop</a>
+        </section>
+      </main>
+
+      <footer>
+        <div class="footer-content">
+          <div>
+            <strong>S&amp;F Agritech</strong>
+            <p>Field innovation, data automation, and apparel inspired by USDA entomology plates.</p>
+          </div>
+          <div>
+            <p>&copy; <span id="year"></span> S&amp;F Agritech. All rights reserved.</p>
+            <div class="socials">
+              <a href="https://www.linkedin.com" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://www.instagram.com" target="_blank" rel="noopener">Instagram</a>
+              <a href="mailto:hello@sfagritech.com">Email</a>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/apparel.html
+++ b/apparel.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>S&F Heritage Apparel | S&F Agritech</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <div class="site-wrapper">
+      <header class="subpage-header">
+        <nav>
+          <div class="logo">S&amp;F Agritech</div>
+          <div class="utility-nav">
+            <a href="index.html">Home</a>
+            <a href="biostimulant-field-work.html">Biostimulant Field Work</a>
+            <a href="ai-automation.html">AI Automation Workflows</a>
+            <a href="apparel.html">Heritage Apparel</a>
+            <a href="mailto:hello@sfagritech.com">Contact</a>
+          </div>
+        </nav>
+      </header>
+
+      <section class="page-hero">
+        <nav class="breadcrumb"><a href="index.html">Home</a> &raquo; Heritage Apparel</nav>
+        <h1>S&amp;F Heritage Apparel</h1>
+        <p>
+          Limited-run shirts and hats inspired by vintage USDA Bureau of Entomology plates. Wear your love for resilient crops and precision scouting.
+        </p>
+      </section>
+
+      <main>
+        <section>
+          <h2 class="section-title">The archive collection</h2>
+          <p>
+            Each garment features restored illustrations sourced from USDA Circulars and Farmers&rsquo; Bulletins originally published between 1890 and 1935. We pair these visuals with modern, breathable fabrics ready for field days or conference floors.
+          </p>
+          <div class="product-grid">
+            <article class="product-card">
+              <img src="assets/img/helioverpa-zea-plate.svg" alt="Illustrated Helicoverpa zea plate" />
+              <h3>Scout&rsquo;s Honor Tee</h3>
+              <p>
+                Ringspun cotton tee in field green featuring the <em>Helicoverpa zea</em> life cycle, annotated with USDA Farmers&rsquo; Bulletin No. 1323 references.
+              </p>
+              <p class="price">$32</p>
+              <a class="btn btn-outline" href="mailto:hello@sfagritech.com?subject=Scout%27s%20Honor%20Tee">Reserve yours</a>
+            </article>
+            <article class="product-card">
+              <img src="assets/img/coccinellidae-lacewing-plate.svg" alt="Coccinellidae and lacewing study plate" />
+              <h3>Beneficial Brigade Cap</h3>
+              <p>
+                Brushed cotton dad hat embroidered with lady beetles and lacewing sketches adapted from USDA Circular No. 66 on natural enemies.
+              </p>
+              <p class="price">$28</p>
+              <a class="btn btn-outline" href="mailto:hello@sfagritech.com?subject=Beneficial%20Brigade%20Cap">Join the waitlist</a>
+            </article>
+            <article class="product-card">
+              <img src="assets/img/hardiness-zones-plate.svg" alt="USDA hardiness zone overlay plate" />
+              <h3>Field Reference Jacket</h3>
+              <p>
+                Lightweight canvas layer with a printed map of USDA Plant Hardiness Zones and interior label citing key pest thresholds for specialty crops.
+              </p>
+              <p class="price">$98</p>
+              <a class="btn btn-outline" href="mailto:hello@sfagritech.com?subject=Field%20Reference%20Jacket">Pre-order</a>
+            </article>
+            <article class="product-card">
+              <img src="assets/img/orthoptera-compendium-plate.svg" alt="Orthoptera pest compendium plate" />
+              <h3>USDA Plate Series</h3>
+              <p>
+                Quarterly drop of tees featuring curated pest and beneficial insect plates. Includes provenance cards linking to digitized USDA archives.
+              </p>
+              <p class="price">$120 / 4-pack</p>
+              <a class="btn btn-outline" href="mailto:hello@sfagritech.com?subject=USDA%20Plate%20Series">Subscribe</a>
+            </article>
+          </div>
+        </section>
+
+        <section class="highlight">
+          <h3>Responsible sourcing</h3>
+          <p>
+            Garments are produced in WRAP-certified facilities with water-based inks. Every order funds digitization of additional USDA pest management resources for our community archive.
+          </p>
+          <div class="badge-list">
+            <span class="badge">Organic or recycled fabrics</span>
+            <span class="badge">Small-batch printing</span>
+            <span class="badge">USDA archive preservation</span>
+            <span class="badge">Field-ready durability</span>
+          </div>
+        </section>
+
+        <section class="cta">
+          <h2>Outfit your crew</h2>
+          <p>
+            Need co-branded gear for your next field day or product launch? We&rsquo;ll combine your logo with our USDA archive assets for a bespoke drop.
+          </p>
+          <a class="btn btn-primary" href="mailto:hello@sfagritech.com">Start a collaboration</a>
+        </section>
+      </main>
+
+      <footer>
+        <div class="footer-content">
+          <div>
+            <strong>S&amp;F Agritech</strong>
+            <p>Field innovation, data automation, and apparel inspired by USDA entomology plates.</p>
+          </div>
+          <div>
+            <p>&copy; <span id="year"></span> S&amp;F Agritech. All rights reserved.</p>
+            <div class="socials">
+              <a href="https://www.linkedin.com" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://www.instagram.com" target="_blank" rel="noopener">Instagram</a>
+              <a href="mailto:hello@sfagritech.com">Email</a>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,663 @@
+:root {
+  --forest: #1d4e3d;
+  --sage: #6c8f6b;
+  --cream: #f4f1e8;
+  --gold: #c6a15b;
+  --charcoal: #2f2f2f;
+  --white: #ffffff;
+  --transition: all 0.3s ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Montserrat", "Helvetica Neue", Arial, sans-serif;
+  color: var(--charcoal);
+  background-color: var(--cream);
+  line-height: 1.6;
+}
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 0.5rem 0.75rem;
+  background: #0b5;
+  color: #fff;
+  border-radius: 4px;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus,
+button:focus {
+  outline: 2px solid #28b868;
+  outline-offset: 2px;
+}
+
+a:hover,
+a:focus {
+  color: var(--forest);
+}
+
+header {
+  background: linear-gradient(135deg, rgba(29, 78, 61, 0.95), rgba(108, 143, 107, 0.9)), url("https://images.unsplash.com/photo-1524592094714-0f0654e20314?auto=format&fit=crop&w=1600&q=80") center/cover;
+  color: var(--white);
+  padding: 1.5rem 0 5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(29, 78, 61, 0.65);
+  z-index: 0;
+}
+
+nav {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+nav .logo {
+  font-weight: 700;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  font-size: 1.1rem;
+}
+
+.logo a {
+  text-decoration: none;
+  color: inherit;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1.25rem;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  font-weight: 500;
+  transition: var(--transition);
+}
+
+nav a:hover,
+nav a:focus {
+  color: var(--gold);
+}
+
+.subpage-header {
+  background: linear-gradient(135deg, rgba(29, 78, 61, 0.94), rgba(108, 143, 107, 0.88));
+  color: var(--white);
+  padding: 1.25rem 0;
+  box-shadow: 0 12px 24px rgba(29, 78, 61, 0.18);
+  position: relative;
+  z-index: 3;
+}
+
+.subpage-header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(29, 78, 61, 0.85), rgba(198, 161, 91, 0.25));
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.subpage-header nav {
+  position: relative;
+}
+
+.subpage-header .logo,
+.subpage-header a {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.subpage-header a:hover,
+.subpage-header a:focus {
+  color: var(--gold);
+}
+
+.hero {
+  position: relative;
+  z-index: 2;
+  max-width: 1100px;
+  margin: 4rem auto 0;
+  padding: 0 1.5rem;
+  text-align: left;
+}
+
+.hero h1 {
+  font-size: clamp(2.25rem, 5vw, 3.25rem);
+  margin-bottom: 1rem;
+  letter-spacing: 1px;
+}
+
+.hero p {
+  max-width: 540px;
+  font-size: 1.1rem;
+  margin-bottom: 2rem;
+}
+
+.hero .cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 1px;
+  transition: var(--transition);
+}
+
+.btn-primary {
+  background: var(--gold);
+  color: var(--charcoal);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  background: #b68f42;
+}
+
+.btn-outline {
+  border: 2px solid var(--white);
+  color: var(--white);
+}
+
+.btn-outline:hover,
+.btn-outline:focus {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+}
+
+.section-title {
+  font-size: clamp(1.75rem, 3.8vw, 2.4rem);
+  margin-bottom: 1.5rem;
+  text-align: left;
+  color: var(--forest);
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.grid-3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+@media (max-width: 900px) {
+  .grid-3 {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .grid-3 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  background: var(--white);
+  border-radius: 18px;
+  padding: 1.75rem;
+  box-shadow: 0 12px 30px rgba(29, 78, 61, 0.12);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.card:hover,
+.card:focus-within {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  color: var(--forest);
+}
+
+.card p {
+  margin-bottom: 1rem;
+}
+
+.highlight {
+  background: var(--white);
+  border-left: 4px solid var(--gold);
+  padding: 1.5rem;
+  margin: 2rem 0;
+  border-radius: 12px;
+}
+
+section.cta {
+  margin-top: 3.5rem;
+  padding: 2.5rem;
+  background: linear-gradient(135deg, rgba(29, 78, 61, 0.9), rgba(108, 143, 107, 0.8));
+  border-radius: 24px;
+  color: var(--white);
+  text-align: center;
+  box-shadow: 0 15px 40px rgba(29, 78, 61, 0.2);
+}
+
+section.cta h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+section.cta p {
+  margin-bottom: 1.5rem;
+}
+
+footer {
+  background: var(--forest);
+  color: var(--white);
+  padding: 2rem 1.5rem;
+}
+
+footer .footer-content {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+footer p {
+  margin: 0.25rem 0;
+}
+
+footer .socials {
+  display: flex;
+  gap: 1rem;
+}
+
+.badge-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.badge {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.5px;
+}
+
+.hero-img {
+  display: block;
+  width: min(420px, 100%);
+  max-width: 100%;
+  height: auto;
+  aspect-ratio: 3 / 2;
+  object-fit: cover;
+  border-radius: 24px;
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.25);
+  border: 3px solid rgba(255, 255, 255, 0.3);
+}
+
+.hero-content {
+  display: grid;
+  gap: 2.5rem;
+  align-items: center;
+}
+
+@media (min-width: 900px) {
+  .hero-content {
+    grid-template-columns: 1.1fr 0.9fr;
+  }
+}
+
+@media (max-width: 768px) {
+  nav ul {
+    display: none;
+  }
+
+  header {
+    padding-bottom: 3.5rem;
+  }
+
+  .hero {
+    text-align: center;
+  }
+
+  .hero p {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .hero .cta-group {
+    justify-content: center;
+  }
+
+  .hero-img {
+    justify-self: center;
+  }
+}
+
+.page-hero {
+  background: linear-gradient(135deg, rgba(29, 78, 61, 0.92), rgba(198, 161, 91, 0.75)), url("https://images.unsplash.com/photo-1470246973918-29a93221c455?auto=format&fit=crop&w=1600&q=80") center/cover;
+  color: var(--white);
+  padding: 6rem 1.5rem 5rem;
+  text-align: center;
+  position: relative;
+}
+
+.page-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(29, 78, 61, 0.65);
+}
+
+.page-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.page-hero h1 {
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  margin-bottom: 1rem;
+}
+
+.page-hero p {
+  max-width: 640px;
+  margin: 0.5rem auto 0;
+}
+
+.breadcrumb {
+  margin: 0 auto 1rem;
+  max-width: 1100px;
+  padding: 0 1.5rem;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.9rem;
+}
+
+.breadcrumb a {
+  color: rgba(255, 255, 255, 0.9);
+  text-decoration: underline;
+}
+
+.split {
+  display: grid;
+  gap: 2.5rem;
+}
+
+@media (min-width: 960px) {
+  .split {
+    grid-template-columns: 1.1fr 0.9fr;
+    align-items: start;
+  }
+}
+
+.list {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.list li {
+  margin-bottom: 0.6rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  background: var(--white);
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
+}
+
+.table th,
+.table td {
+  padding: 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.table th {
+  background: rgba(29, 78, 61, 0.1);
+  color: var(--forest);
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  margin: 1.5rem 0 0;
+  border-radius: 16px;
+  box-shadow: 0 8px 20px rgba(29, 78, 61, 0.12);
+  background: var(--white);
+}
+
+.table-wrapper .table {
+  margin: 0;
+  box-shadow: none;
+}
+
+.workflow-matrix td,
+.workflow-matrix th {
+  min-width: 160px;
+}
+
+.workflow-matrix td:last-child {
+  font-style: italic;
+  color: var(--sage);
+}
+
+.badge.green {
+  background: rgba(108, 143, 107, 0.18);
+  color: var(--forest);
+}
+
+.badge.gold {
+  background: rgba(198, 161, 91, 0.18);
+  color: var(--gold);
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2rem;
+}
+
+.product-card {
+  background: var(--white);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 28px rgba(29, 78, 61, 0.14);
+  display: flex;
+  flex-direction: column;
+}
+
+.product-card img {
+  width: 100%;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+  border: 1px solid rgba(29, 78, 61, 0.18);
+  background: rgba(244, 241, 232, 0.9);
+  object-fit: contain;
+  padding: 1rem;
+}
+
+.product-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  color: var(--forest);
+}
+
+.product-card p {
+  flex-grow: 1;
+}
+
+.price {
+  font-weight: 700;
+  color: var(--forest);
+  margin: 0.5rem 0 1rem;
+}
+
+.tagline {
+  font-style: italic;
+  font-size: 0.95rem;
+  color: rgba(47, 47, 47, 0.85);
+}
+
+.testimonial {
+  background: var(--white);
+  border-radius: 18px;
+  padding: 1.75rem;
+  box-shadow: 0 10px 24px rgba(29, 78, 61, 0.12);
+  position: relative;
+}
+
+.testimonial::before {
+  content: "\201C";
+  font-size: 3rem;
+  color: rgba(198, 161, 91, 0.6);
+  position: absolute;
+  top: -1.5rem;
+  left: 1rem;
+}
+
+.contact-card {
+  background: linear-gradient(135deg, rgba(108, 143, 107, 0.95), rgba(29, 78, 61, 0.85));
+  color: var(--white);
+  border-radius: 18px;
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-card h3 {
+  margin: 0;
+}
+
+.contact-card a {
+  color: var(--white);
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.badge.usda {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px dashed rgba(255, 255, 255, 0.4);
+  padding: 0.6rem 1rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.hero-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.2);
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.hero-tag span {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--gold);
+}
+
+blockquote {
+  margin: 0;
+  padding: 1.5rem 2rem;
+  background: rgba(198, 161, 91, 0.15);
+  border-left: 4px solid var(--gold);
+  border-radius: 12px;
+  font-style: italic;
+}
+
+.site-wrapper {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex: 1;
+}
+
+.utility-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.utility-nav a {
+  font-size: 0.85rem;
+}
+
+.utility-nav a[aria-current="page"] {
+  color: #124c32;
+  font-weight: 600;
+  border-bottom: 2px solid #28b868;
+}
+
+@media (max-width: 600px) {
+  section.cta {
+    padding: 2rem 1.5rem;
+  }
+
+  .contact-card {
+    padding: 1.5rem;
+  }
+}

--- a/assets/img/coccinellidae-lacewing-plate.svg
+++ b/assets/img/coccinellidae-lacewing-plate.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 640">
+  <style>
+    .frame { fill: none; stroke: #2f2f2f; stroke-width: 4; }
+    .label { font-family: 'Montserrat', 'Helvetica Neue', Arial, sans-serif; fill: #2f2f2f; font-size: 20px; letter-spacing: 3px; text-transform: uppercase; }
+    .caption { font-family: 'Montserrat', 'Helvetica Neue', Arial, sans-serif; fill: #2f2f2f; font-size: 16px; letter-spacing: 1px; }
+    .outline { fill: none; stroke: #2f2f2f; stroke-width: 4; stroke-linecap: round; }
+    .detail { fill: none; stroke: #c6a15b; stroke-width: 2.8; stroke-linecap: round; stroke-dasharray: 10 8; }
+  </style>
+  <rect class="frame" x="20" y="20" width="480" height="600" rx="8" />
+  <text class="label" x="50%" y="70" text-anchor="middle">PLATE XLII</text>
+  <text class="caption" x="50%" y="105" text-anchor="middle">Coccinellidae &amp; Chrysopidae Beneficial Forms &mdash; USDA Circular 66</text>
+  <g transform="translate(156 360)">
+    <ellipse class="outline" cx="0" cy="-110" rx="48" ry="58" />
+    <path class="outline" d="M-48 -110 C -88 -20 -86 60 -40 150" />
+    <path class="outline" d="M48 -110 C 88 -20 86 60 40 150" />
+    <ellipse class="outline" cx="0" cy="40" rx="60" ry="86" />
+    <line class="detail" x1="0" y1="-168" x2="0" y2="190" />
+    <path class="detail" d="M-42 -20 Q 0 -46 42 -20" />
+    <path class="detail" d="M-38 36 Q 0 12 38 36" />
+    <path class="detail" d="M-30 98 Q 0 64 30 98" />
+  </g>
+  <g transform="translate(360 360)">
+    <path class="outline" d="M-110 -60 Q 0 -200 110 -60" />
+    <path class="outline" d="M-110 40 Q 0 180 110 40" />
+    <path class="detail" d="M-96 -40 Q 0 -140 96 -40" />
+    <path class="detail" d="M-96 18 Q 0 120 96 18" />
+    <line class="outline" x1="0" y1="-120" x2="0" y2="150" />
+    <circle class="outline" cx="0" cy="-136" r="14" />
+    <path class="detail" d="M-60 -10 L60 -10" />
+    <path class="detail" d="M-42 48 L42 48" />
+  </g>
+  <text class="caption" x="50%" y="590" text-anchor="middle">Lady beetle adult and lacewing wing venation for beneficial scouting guides.</text>
+</svg>

--- a/assets/img/hardiness-zones-plate.svg
+++ b/assets/img/hardiness-zones-plate.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 640">
+  <style>
+    .frame { fill: none; stroke: #2f2f2f; stroke-width: 4; }
+    .label { font-family: 'Montserrat', 'Helvetica Neue', Arial, sans-serif; fill: #2f2f2f; font-size: 20px; letter-spacing: 3px; text-transform: uppercase; }
+    .caption { font-family: 'Montserrat', 'Helvetica Neue', Arial, sans-serif; fill: #2f2f2f; font-size: 16px; letter-spacing: 1px; }
+    .zone { fill: none; stroke-width: 3.2; stroke-linecap: round; }
+  </style>
+  <rect class="frame" x="20" y="20" width="480" height="600" rx="8" />
+  <text class="label" x="50%" y="70" text-anchor="middle">PLATE XII</text>
+  <text class="caption" x="50%" y="105" text-anchor="middle">USDA Plant Hardiness Overlays &mdash; 1938 Service Map</text>
+  <g transform="translate(260 340)">
+    <path class="zone" stroke="#6c8f6b" d="M-150 -60 C -110 -160 120 -160 160 -50 C 200 60 120 150 -10 200 C -140 150 -200 40 -150 -60Z" />
+    <path class="zone" stroke="#c6a15b" d="M-120 -40 C -90 -120 80 -130 120 -30 C 150 60 90 120 -10 160 C -110 120 -160 20 -120 -40Z" />
+    <path class="zone" stroke="#2f2f2f" d="M-84 -20 C -64 -86 38 -94 78 -18 C 100 48 62 92 -10 120 C -82 92 -120 12 -84 -20Z" />
+    <circle fill="#f4f1e8" stroke="#2f2f2f" stroke-width="3" cx="-30" cy="-10" r="14" />
+    <circle fill="#f4f1e8" stroke="#2f2f2f" stroke-width="3" cx="52" cy="40" r="14" />
+    <line stroke="#2f2f2f" stroke-width="2" x1="-120" y1="-160" x2="90" y2="200" stroke-dasharray="12 12" />
+  </g>
+  <text class="caption" x="50%" y="590" text-anchor="middle">Zones 8a&ndash;10b reference for apparel interior labelling.</text>
+</svg>

--- a/assets/img/helioverpa-zea-plate.svg
+++ b/assets/img/helioverpa-zea-plate.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 640">
+  <style>
+    .frame { fill: none; stroke: #2f2f2f; stroke-width: 4; }
+    .label { font-family: 'Montserrat', 'Helvetica Neue', Arial, sans-serif; fill: #2f2f2f; font-size: 20px; letter-spacing: 3px; text-transform: uppercase; }
+    .caption { font-family: 'Montserrat', 'Helvetica Neue', Arial, sans-serif; fill: #2f2f2f; font-size: 16px; letter-spacing: 1px; }
+    .outline { fill: none; stroke: #2f2f2f; stroke-width: 5; stroke-linecap: round; }
+    .detail { fill: none; stroke: #6c8f6b; stroke-width: 3; stroke-linecap: round; stroke-dasharray: 8 10; }
+  </style>
+  <rect class="frame" x="20" y="20" width="480" height="600" rx="8" />
+  <text class="label" x="50%" y="70" text-anchor="middle">PLATE XXIV</text>
+  <text class="caption" x="50%" y="105" text-anchor="middle">Helicoverpa zea &mdash; USDA Farmers' Bulletin 1323</text>
+  <g transform="translate(260 360)">
+    <ellipse class="outline" cx="0" cy="-160" rx="48" ry="54" />
+    <ellipse class="outline" cx="0" cy="-72" rx="70" ry="90" />
+    <path class="outline" d="M-70 -72 C -120 -42 -138 48 -80 142" />
+    <path class="outline" d="M70 -72 C 120 -42 138 48 80 142" />
+    <path class="outline" d="M-54 30 C -78 72 -60 148 -12 190" />
+    <path class="outline" d="M54 30 C 78 72 60 148 12 190" />
+    <ellipse class="outline" cx="0" cy="120" rx="45" ry="70" />
+    <line class="outline" x1="0" y1="-214" x2="0" y2="210" />
+    <line class="detail" x1="-90" y1="-140" x2="-162" y2="-210" />
+    <line class="detail" x1="90" y1="-140" x2="162" y2="-210" />
+    <circle class="detail" cx="0" cy="-120" r="18" />
+    <path class="detail" d="M-30 -20 Q 0 -60 30 -20" />
+    <path class="detail" d="M-28 60 Q 0 20 28 60" />
+    <path class="detail" d="M-22 120 Q 0 90 22 120" />
+  </g>
+  <text class="caption" x="50%" y="590" text-anchor="middle">Larval and adult morphology reference for ear-feeding Lepidoptera.</text>
+</svg>

--- a/assets/img/orthoptera-compendium-plate.svg
+++ b/assets/img/orthoptera-compendium-plate.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 640">
+  <style>
+    .frame { fill: none; stroke: #2f2f2f; stroke-width: 4; }
+    .label { font-family: 'Montserrat', 'Helvetica Neue', Arial, sans-serif; fill: #2f2f2f; font-size: 20px; letter-spacing: 3px; text-transform: uppercase; }
+    .caption { font-family: 'Montserrat', 'Helvetica Neue', Arial, sans-serif; fill: #2f2f2f; font-size: 16px; letter-spacing: 1px; }
+    .outline { fill: none; stroke: #2f2f2f; stroke-width: 4; stroke-linecap: round; }
+    .detail { fill: none; stroke: #6c8f6b; stroke-width: 2.4; stroke-dasharray: 6 8; stroke-linecap: round; }
+  </style>
+  <rect class="frame" x="20" y="20" width="480" height="600" rx="8" />
+  <text class="label" x="50%" y="70" text-anchor="middle">PLATE LVIII</text>
+  <text class="caption" x="50%" y="105" text-anchor="middle">Orthoptera Pest Complex &mdash; USDA Bulletin 779</text>
+  <g transform="translate(260 330)">
+    <path class="outline" d="M-100 -10 C -160 -110 -120 -200 0 -180 C 120 -200 160 -110 100 -10" />
+    <path class="outline" d="M-90 20 C -130 100 -110 180 -40 210" />
+    <path class="outline" d="M90 20 C 130 100 110 180 40 210" />
+    <ellipse class="outline" cx="0" cy="-120" rx="40" ry="48" />
+    <ellipse class="outline" cx="0" cy="-40" rx="70" ry="80" />
+    <ellipse class="outline" cx="0" cy="110" rx="52" ry="70" />
+    <line class="outline" x1="0" y1="-210" x2="0" y2="220" />
+    <path class="detail" d="M-60 -66 Q 0 -110 60 -66" />
+    <path class="detail" d="M-50 -20 Q 0 -50 50 -20" />
+    <path class="detail" d="M-46 26 Q 0 0 46 26" />
+    <path class="detail" d="M-42 74 Q 0 46 42 74" />
+    <path class="detail" d="M-36 126 Q 0 96 36 126" />
+  </g>
+  <text class="caption" x="50%" y="590" text-anchor="middle">Comparative hindwing spread for grasshopper complex identification.</text>
+</svg>

--- a/biostimulant-field-work.html
+++ b/biostimulant-field-work.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Biostimulant Field Work | S&F Agritech</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <div class="site-wrapper">
+      <header class="subpage-header">
+        <nav>
+          <div class="logo">S&amp;F Agritech</div>
+          <div class="utility-nav">
+            <a href="index.html">Home</a>
+            <a href="biostimulant-field-work.html">Biostimulant Field Work</a>
+            <a href="ai-automation.html">AI Automation Workflows</a>
+            <a href="apparel.html">Heritage Apparel</a>
+            <a href="mailto:hello@sfagritech.com">Contact</a>
+          </div>
+        </nav>
+      </header>
+
+      <section class="page-hero">
+        <nav class="breadcrumb"><a href="index.html">Home</a> &raquo; Biostimulant Field Work</nav>
+        <h1>Biostimulant Field Work Services</h1>
+        <p>
+          Full-season trial programs that align with USDA, WSDA, and CDFA expectations while capturing the practical realities of on-farm adoption.
+        </p>
+      </section>
+
+      <main>
+        <section class="split">
+          <div>
+            <h2 class="section-title">Purpose-built trial design</h2>
+            <p>
+              We collaborate with your agronomy, product, and commercial teams to translate research questions into statistically defensible field experiments. Every plot layout, application timing, and sampling event is mapped against crop phenology and regulatory milestones.
+            </p>
+            <ul class="list">
+              <li>Protocol development referencing USDA and AAPFCO guidance</li>
+              <li>Randomized complete block &amp; strip trial configurations</li>
+              <li>Integrated pest management (IPM) overlays with USDA pest fact sheets</li>
+              <li>In-season dashboards to monitor NDVI, tissue analyses, and weather events</li>
+            </ul>
+            <blockquote>
+              Our crews maintain a private archive of USDA Extension pest plates to ensure every scouting note uses the same taxonomy your reviewers expect.
+            </blockquote>
+          </div>
+          <div class="card">
+            <h3>What&rsquo;s included</h3>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Phase</th>
+                  <th>Deliverables</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Planning</td>
+                  <td>Protocol design, site selection, regulatory brief</td>
+                </tr>
+                <tr>
+                  <td>Execution</td>
+                  <td>Application oversight, digital scouting log, photo archive</td>
+                </tr>
+                <tr>
+                  <td>Analysis</td>
+                  <td>ANOVA &amp; regression outputs, GIS layers, USDA-referenced pest summary</td>
+                </tr>
+                <tr>
+                  <td>Enablement</td>
+                  <td>Sales one-pager, webinar outline, and automation triggers</td>
+                </tr>
+              </tbody>
+            </table>
+            <a class="btn btn-primary" href="mailto:hello@sfagritech.com">Book a scoping session</a>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Field reporting built for action</h2>
+          <div class="grid grid-3">
+            <article class="card">
+              <h3>Crop-ready insights</h3>
+              <p>
+                Layer yield, quality, and tissue metrics into a single narrative backed by USDA crop bulletins and your internal ROI targets.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Spatial storytelling</h3>
+              <p>
+                Interactive maps showcase treatment effects, pest pressure, and microclimate anomalies to inform the next application cycle.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Enablement assets</h3>
+              <p>
+                We deliver templated slide decks, social-ready visuals, and AI prompts so your team can teach, sell, and support without reinventing the wheel.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Recent engagements</h2>
+          <div class="grid">
+            <article class="card">
+              <h3>Leafy greens consortium</h3>
+              <p>
+                Coordinated a multi-ranch calcium biostimulant program with replicated RCBD trials, drone imagery overlays, and USDA specialty crop grant compliance.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Permanent crop demo blocks</h3>
+              <p>
+                Managed a three-year pecan vigor project blending biostimulant fertigation, pest exclusion nets, and USDA pecan scab monitoring references.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Protected ag accelerators</h3>
+              <p>
+                Delivered rapid-cycle trials for greenhouse berries, translating USDA greenhouse IPM sheets into bilingual training modules.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="cta">
+          <h2>Let&rsquo;s design your next trial season</h2>
+          <p>
+            Share your target crops, geographies, and regulatory checkpoints. We&rsquo;ll assemble a turnkey program that your growers and reviewers can trust.
+          </p>
+          <a class="btn btn-primary" href="mailto:hello@sfagritech.com">Contact S&amp;F</a>
+        </section>
+      </main>
+
+      <footer>
+        <div class="footer-content">
+          <div>
+            <strong>S&amp;F Agritech</strong>
+            <p>Field innovation, data automation, and apparel inspired by USDA entomology plates.</p>
+          </div>
+          <div>
+            <p>&copy; <span id="year"></span> S&amp;F Agritech. All rights reserved.</p>
+            <div class="socials">
+              <a href="https://www.linkedin.com" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://www.instagram.com" target="_blank" rel="noopener">Instagram</a>
+              <a href="mailto:hello@sfagritech.com">Email</a>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="S&F Agritech helps specialty crop teams run biostimulant field trials, deploy AI automation workflows, and launch heritage apparel inspired by USDA entomology. Practical agronomy, modern ops." />
+    <title>S&F Agritech | Field Intelligence for Resilient Crops</title>
+    <link rel="canonical" href="https://www.sfagritech.com/" />
+    <meta property="og:title" content="S&F Agritech | Field Intelligence for Resilient Crops" />
+    <meta property="og:description" content="Biostimulant field work, AI automation workflows, and heritage apparel for specialty crops." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://www.sfagritech.com/" />
+    <meta property="og:image" content="https://www.sfagritech.com/assets/img/og-hero.jpg" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="S&F Agritech | Field Intelligence for Resilient Crops" />
+    <meta name="twitter:description" content="Biostimulant field work, AI automation workflows, and heritage apparel for specialty crops." />
+    <meta name="twitter:image" content="https://www.sfagritech.com/assets/img/og-hero.jpg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="icon" href="/assets/img/favicon.ico" />
+    <link rel="preload" as="image" href="https://images.unsplash.com/photo-1576086213369-97a306d36557?auto=format&fit=crop&w=1600&q=80" imagesrcset="https://images.unsplash.com/photo-1576086213369-97a306d36557?auto=format&fit=crop&w=900&q=80 900w, https://images.unsplash.com/photo-1576086213369-97a306d36557?auto=format&fit=crop&w=1600&q=80 1600w" imagesizes="(max-width: 900px) 100vw, 50vw" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "S&F Agritech",
+        "url": "https://www.sfagritech.com/",
+        "logo": "https://www.sfagritech.com/assets/img/logo.png",
+        "sameAs": [
+          "https://www.linkedin.com/company/sfagritech",
+          "https://www.instagram.com/sfagritech"
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <div class="site-wrapper">
+      <header role="banner">
+        <nav aria-label="Primary">
+          <div class="logo"><a href="index.html" aria-label="S&F Agritech home">S&F Agritech</a></div>
+          <div class="utility-nav" role="navigation">
+            <a href="index.html" aria-current="page">Home</a>
+            <a href="biostimulant-field-work.html">Biostimulant Field Work</a>
+            <a href="ai-automation.html">AI Automation Workflows</a>
+            <a href="apparel.html">Heritage Apparel</a>
+            <a href="#contact">Contact</a>
+          </div>
+        </nav>
+        <div class="hero">
+          <div class="hero-content">
+            <div>
+              <div class="hero-tag"><span></span>Field Intelligence. Modern Stewardship.</div>
+              <h1>Science-first agronomy and automation for specialty crop teams.</h1>
+              <p>
+                We partner with growers, input manufacturers, and ag-tech operators to validate biostimulants, unlock AI-assisted workflows, and celebrate the heritage of integrated pest management.
+              </p>
+              <div class="cta-group">
+                <a class="btn btn-primary" href="biostimulant-field-work.html" data-analytics="cta_explore_field_trials">Explore Field Trials</a>
+                <a class="btn btn-outline" href="#contact" data-analytics="cta_discovery_call">Schedule a Discovery Call</a>
+              </div>
+            </div>
+            <img
+              class="hero-img"
+              src="https://images.unsplash.com/photo-1576086213369-97a306d36557?auto=format&fit=crop&w=900&q=80"
+              srcset="https://images.unsplash.com/photo-1576086213369-97a306d36557?auto=format&fit=crop&w=900&q=80 900w, https://images.unsplash.com/photo-1576086213369-97a306d36557?auto=format&fit=crop&w=1600&q=80 1600w"
+              sizes="(max-width: 900px) 100vw, 50vw"
+              width="900"
+              height="600"
+              alt="Agronomist scouting a field in specialty crops"
+              fetchpriority="high"
+              decoding="async"
+            />
+          </div>
+        </div>
+      </header>
+
+      <main id="main" tabindex="-1">
+        <section>
+          <h2 class="section-title">What we deliver</h2>
+          <div class="grid grid-3">
+            <article class="card">
+              <h3>Biostimulant field work</h3>
+              <p>
+                Custom protocols, replicated trial design, and statistically defensible reports that accelerate product registrations and sales conversations.
+              </p>
+              <a class="btn btn-outline" href="biostimulant-field-work.html">See our field services</a>
+            </article>
+            <article class="card">
+              <h3>AI automation workflows</h3>
+              <p>
+                Purpose-built AI playbooks that streamline scouting notes, tissue data interpretation, and grower engagement without overwhelming your crew.
+              </p>
+              <a class="btn btn-outline" href="ai-automation.html">Review workflow ideas</a>
+            </article>
+            <article class="card">
+              <h3>Heritage apparel</h3>
+              <p>
+                Premium S&F gear featuring vintage USDA pest illustrations&mdash;a wearable nod to our roots in botany and applied entomology.
+              </p>
+              <a class="btn btn-outline" href="apparel.html">Shop the collection</a>
+            </article>
+          </div>
+        </section>
+
+        <section class="highlight">
+          <h3>Field-tested with specialty crop producers across the Southwest</h3>
+          <p>
+            From leafy greens in the Salinas Valley to pecan orchards across Texas, we structure experiments that respect the crop, the crew, and the bottom line. Every project concludes with clear, visual reporting, GIS-tagged observations, and grower-ready messaging.
+          </p>
+          <div class="badge-list">
+            <span class="badge">Replicated small plot trials</span>
+            <span class="badge">On-farm demonstrations</span>
+            <span class="badge">USDA-aligned IPM documentation</span>
+            <span class="badge">Data dashboards &amp; automation</span>
+          </div>
+        </section>
+
+        <section>
+          <h2 class="section-title">Why teams choose S&F</h2>
+          <div class="grid grid-3">
+            <article class="card">
+              <h3>Regulatory fluency</h3>
+              <p>
+                Our agronomists speak the language of WSDA, CDFA, and USDA reviewers. We prep your dossiers with the right evidence before you knock on the door.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Operational empathy</h3>
+              <p>
+                We integrate seamlessly with in-house field crews, respecting spray schedules, irrigation windows, and labor realities while still collecting robust data.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Modern storytelling</h3>
+              <p>
+                Insight dashboards, automation workflows, and heritage visuals help your sales and marketing teams translate agronomic wins into repeatable revenue.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="cta">
+          <h2>Ready to build your next milestone?</h2>
+          <p>
+            Let&rsquo;s scope the trials, the automations, and the merchandising that will help your team scale.
+          </p>
+          <a class="btn btn-primary" href="mailto:hello@sfagritech.com">Start the conversation</a>
+        </section>
+
+        <section id="contact" style="margin-top: 4rem;">
+          <div class="grid">
+            <div class="contact-card">
+              <h3>Talk with our founders</h3>
+              <p>
+                Share your crop mix, regulatory targets, or campaign ideas and we&rsquo;ll assemble a roadmap that matches your timeline.
+              </p>
+              <a href="mailto:hello@sfagritech.com">hello@sfagritech.com</a>
+              <div class="badge usda">USDA Pest Reference Archive &mdash; curated by S&amp;F</div>
+            </div>
+            <div class="testimonial">
+              <p>
+                “S&amp;F translated our R&amp;D backlog into a season-long plan, complete with AI-generated scouting summaries and gorgeous heritage visuals for our sales tour.”
+              </p>
+              <p class="tagline">Director of Product Marketing, Specialty Crop Biostimulant Firm</p>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer>
+        <div class="footer-content">
+          <div>
+            <strong>S&amp;F Agritech</strong>
+            <p>Field innovation, data automation, and apparel inspired by USDA entomology plates.</p>
+            <p class="footer-meta">Based in Texas • Serving specialty crop teams nationwide</p>
+          </div>
+          <div>
+            <p>&copy; <span id="year"></span> S&amp;F Agritech. All rights reserved.</p>
+            <div class="socials">
+              <a href="https://www.linkedin.com" target="_blank" rel="noopener" aria-label="S&F Agritech on LinkedIn">LinkedIn</a>
+              <a href="https://www.instagram.com" target="_blank" rel="noopener" aria-label="S&F Agritech on Instagram">Instagram</a>
+              <a href="mailto:hello@sfagritech.com">Email</a>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'G-XXXXXXX');
+      // Simple click tracking for elements with data-analytics attribute:
+      document.addEventListener('click', (e) => {
+        const t = e.target.closest('[data-analytics]');
+        if (t) gtag('event', 'click', { event_category: 'cta', event_label: t.getAttribute('data-analytics') });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- enrich the homepage head with meta tags, canonical, JSON-LD, favicon, and preload hints for stronger SEO and sharing previews
- add skip navigation, semantic landmark tweaks, CTA analytics hooks, and GA4 placeholder scripts to improve accessibility and measurement readiness
- update hero media attributes, navigation links, and footer trust copy while refining styles for focus states, grids, cards, and current nav indication

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d9d357404c832f940f9974a77e662c