### PR TITLE
Add skip links and accessible navigation to interior pages

### DIFF
--- a/ai-automation.html
+++ b/ai-automation.html
@@ -10,16 +10,28 @@
     <link rel="stylesheet" href="assets/css/styles.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main">Skip to main content</a>
     <div class="site-wrapper">
-      <nav class="breadcrumb"><a href="index.html">Home</a> &raquo; AI Automation Workflows</nav>
-      <section class="page-hero">
-        <h1>AI Automation for Agronomic Teams</h1>
-        <p>
-          Transform field intelligence into repeatable workflows. We bridge your scouting crews, lab data, and CRM systems using secure automation stacks.
-        </p>
-      </section>
+      <header role="banner">
+        <nav aria-label="Primary">
+          <a class="logo" href="index.html" aria-label="S&amp;F Agritech home">S&amp;F Agritech</a>
+          <div class="utility-nav">
+            <a href="biostimulant-field-work.html">Biostimulant Field Work</a>
+            <a href="ai-automation.html" aria-current="page">AI Automation Workflows</a>
+            <a href="apparel.html">Heritage Apparel</a>
+            <a href="#contact">Contact</a>
+          </div>
+        </nav>
+        <nav class="breadcrumb" aria-label="Breadcrumb"><a href="index.html">Home</a> &raquo; AI Automation Workflows</nav>
+        <section class="page-hero">
+          <h1>AI Automation for Agronomic Teams</h1>
+          <p>
+            Transform field intelligence into repeatable workflows. We bridge your scouting crews, lab data, and CRM systems using secure automation stacks.
+          </p>
+        </section>
+      </header>
 
-      <main>
+      <main id="main" tabindex="-1">
         <section class="split">
           <div>
             <h2 class="section-title">From data friction to guided action</h2>

--- a/apparel.html
+++ b/apparel.html
@@ -10,16 +10,28 @@
     <link rel="stylesheet" href="assets/css/styles.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main">Skip to main content</a>
     <div class="site-wrapper">
-      <nav class="breadcrumb"><a href="index.html">Home</a> &raquo; Heritage Apparel</nav>
-      <section class="page-hero">
-        <h1>S&amp;F Heritage Apparel</h1>
-        <p>
-          Limited-run shirts and hats inspired by vintage USDA Bureau of Entomology plates. Wear your love for resilient crops and precision scouting.
-        </p>
-      </section>
+      <header role="banner">
+        <nav aria-label="Primary">
+          <a class="logo" href="index.html" aria-label="S&amp;F Agritech home">S&amp;F Agritech</a>
+          <div class="utility-nav">
+            <a href="biostimulant-field-work.html">Biostimulant Field Work</a>
+            <a href="ai-automation.html">AI Automation Workflows</a>
+            <a href="apparel.html" aria-current="page">Heritage Apparel</a>
+            <a href="#contact">Contact</a>
+          </div>
+        </nav>
+        <nav class="breadcrumb" aria-label="Breadcrumb"><a href="index.html">Home</a> &raquo; Heritage Apparel</nav>
+        <section class="page-hero">
+          <h1>S&amp;F Heritage Apparel</h1>
+          <p>
+            Limited-run shirts and hats inspired by vintage USDA Bureau of Entomology plates. Wear your love for resilient crops and precision scouting.
+          </p>
+        </section>
+      </header>
 
-      <main>
+      <main id="main" tabindex="-1">
         <section>
           <h2 class="section-title">The archive collection</h2>
           <p>

--- a/biostimulant-field-work.html
+++ b/biostimulant-field-work.html
@@ -10,16 +10,28 @@
     <link rel="stylesheet" href="assets/css/styles.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main">Skip to main content</a>
     <div class="site-wrapper">
-      <nav class="breadcrumb"><a href="index.html">Home</a> &raquo; Biostimulant Field Work</nav>
-      <section class="page-hero">
-        <h1>Biostimulant Field Work Services</h1>
-        <p>
-          Full-season trial programs that align with USDA, WSDA, and CDFA expectations while capturing the practical realities of on-farm adoption.
-        </p>
-      </section>
+      <header role="banner">
+        <nav aria-label="Primary">
+          <a class="logo" href="index.html" aria-label="S&amp;F Agritech home">S&amp;F Agritech</a>
+          <div class="utility-nav">
+            <a href="biostimulant-field-work.html" aria-current="page">Biostimulant Field Work</a>
+            <a href="ai-automation.html">AI Automation Workflows</a>
+            <a href="apparel.html">Heritage Apparel</a>
+            <a href="#contact">Contact</a>
+          </div>
+        </nav>
+        <nav class="breadcrumb" aria-label="Breadcrumb"><a href="index.html">Home</a> &raquo; Biostimulant Field Work</nav>
+        <section class="page-hero">
+          <h1>Biostimulant Field Work Services</h1>
+          <p>
+            Full-season trial programs that align with USDA, WSDA, and CDFA expectations while capturing the practical realities of on-farm adoption.
+          </p>
+        </section>
+      </header>
 
-      <main>
+      <main id="main" tabindex="-1">
         <section class="split">
           <div>
             <h2 class="section-title">Purpose-built trial design</h2>


### PR DESCRIPTION
## Summary
- add skip links so keyboard users can jump directly to the main content on the three interior pages
- wrap each page header in a semantic banner/nav structure with a linked logo back to the home page
- mark the active page link with `aria-current` and ensure each `<main>` is focusable for the skip link target

## Testing
- not run (static HTML)


------
https://chatgpt.com/codex/tasks/task_e_68d9e7a9b220832f899c2ae23ac28f22