### PR TITLE
Add aria labels and shared footer messaging to subpages

### DIFF
--- a/ai-automation.html
+++ b/ai-automation.html
@@ -112,13 +112,14 @@
           <div>
             <strong>S&amp;F Agritech</strong>
             <p>Field innovation, data automation, and apparel inspired by USDA entomology plates.</p>
+            <p class="footer-meta">Based in Texas • Serving specialty crop teams nationwide</p>
           </div>
           <div>
             <p>&copy; <span id="year"></span> S&amp;F Agritech. All rights reserved.</p>
             <div class="socials">
-              <a href="https://www.linkedin.com" target="_blank" rel="noopener">LinkedIn</a>
-              <a href="https://www.instagram.com" target="_blank" rel="noopener">Instagram</a>
-              <a href="mailto:hello@sfagritech.com">Email</a>
+              <a href="https://www.linkedin.com" target="_blank" rel="noopener" aria-label="S&amp;F Agritech on LinkedIn">LinkedIn</a>
+              <a href="https://www.instagram.com" target="_blank" rel="noopener" aria-label="S&amp;F Agritech on Instagram">Instagram</a>
+              <a href="mailto:hello@sfagritech.com" aria-label="Email S&amp;F Agritech">Email</a>
             </div>
           </div>
         </div>

--- a/apparel.html
+++ b/apparel.html
@@ -92,13 +92,14 @@
           <div>
             <strong>S&amp;F Agritech</strong>
             <p>Field innovation, data automation, and apparel inspired by USDA entomology plates.</p>
+            <p class="footer-meta">Based in Texas • Serving specialty crop teams nationwide</p>
           </div>
           <div>
             <p>&copy; <span id="year"></span> S&amp;F Agritech. All rights reserved.</p>
             <div class="socials">
-              <a href="https://www.linkedin.com" target="_blank" rel="noopener">LinkedIn</a>
-              <a href="https://www.instagram.com" target="_blank" rel="noopener">Instagram</a>
-              <a href="mailto:hello@sfagritech.com">Email</a>
+              <a href="https://www.linkedin.com" target="_blank" rel="noopener" aria-label="S&amp;F Agritech on LinkedIn">LinkedIn</a>
+              <a href="https://www.instagram.com" target="_blank" rel="noopener" aria-label="S&amp;F Agritech on Instagram">Instagram</a>
+              <a href="mailto:hello@sfagritech.com" aria-label="Email S&amp;F Agritech">Email</a>
             </div>
           </div>
         </div>

--- a/biostimulant-field-work.html
+++ b/biostimulant-field-work.html
@@ -129,13 +129,14 @@
           <div>
             <strong>S&amp;F Agritech</strong>
             <p>Field innovation, data automation, and apparel inspired by USDA entomology plates.</p>
+            <p class="footer-meta">Based in Texas • Serving specialty crop teams nationwide</p>
           </div>
           <div>
             <p>&copy; <span id="year"></span> S&amp;F Agritech. All rights reserved.</p>
             <div class="socials">
-              <a href="https://www.linkedin.com" target="_blank" rel="noopener">LinkedIn</a>
-              <a href="https://www.instagram.com" target="_blank" rel="noopener">Instagram</a>
-              <a href="mailto:hello@sfagritech.com">Email</a>
+              <a href="https://www.linkedin.com" target="_blank" rel="noopener" aria-label="S&amp;F Agritech on LinkedIn">LinkedIn</a>
+              <a href="https://www.instagram.com" target="_blank" rel="noopener" aria-label="S&amp;F Agritech on Instagram">Instagram</a>
+              <a href="mailto:hello@sfagritech.com" aria-label="Email S&amp;F Agritech">Email</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add descriptive aria-label text to social links on service and apparel pages
- reinforce consistent trust statement in each footer with shared location messaging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9e7ac7b64832f8d98013429bbee8f